### PR TITLE
fix: handle none value

### DIFF
--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -507,7 +507,7 @@ def parsed_aggregate_reports_to_csv_rows(reports):
             row["dmarc_aligned"] = record["alignment"]["dmarc"]
             row["disposition"] = record["policy_evaluated"]["disposition"]
             policy_override_reasons = list(map(
-                lambda r_: r_["type"],
+                lambda r_: r_["type"] or "none",
                 record["policy_evaluated"]
                 ["policy_override_reasons"]))
             policy_override_comments = list(map(

--- a/samples/aggregate/empty_reason.xml
+++ b/samples/aggregate/empty_reason.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feedback>
+  <version>1.0</version>
+  <report_metadata>
+    <org_name>example.org</org_name>
+    <email>noreply-dmarc-support@example.org</email>
+    <extra_contact_info>https://support.example.org/dmarc</extra_contact_info>
+    <report_id>20240125141224705995</report_id>
+    <date_range>
+      <begin>1706159544</begin>
+      <end>1706185733</end>
+    </date_range>
+  </report_metadata>
+  <policy_published>
+    <domain>example.com</domain>
+    <adkim>r</adkim>
+    <aspf>r</aspf>
+    <p>quarantine</p>
+    <sp>quarantine</sp>
+    <pct>100</pct>
+    <fo>1</fo>
+  </policy_published>
+  <record>
+    <row>
+      <source_ip>198.51.100.123</source_ip>
+      <count>2</count>
+      <policy_evaluated>
+        <disposition>none</disposition>
+        <dkim>pass</dkim>
+        <spf>fail</spf>
+        <reason>
+          <type></type>
+          <comment></comment>
+        </reason>
+      </policy_evaluated>
+    </row>
+    <identifiers>
+      <envelope_to>example.net</envelope_to>
+      <envelope_from>example.edu</envelope_from>
+      <header_from>example.com</header_from>
+    </identifiers>
+    <auth_results>
+      <dkim>
+        <domain>example.com</domain>
+        <selector>example</selector>
+        <result>pass</result>
+        <human_result>2048-bit key</human_result>
+      </dkim>
+      <spf>
+        <domain>example.edu</domain>
+        <scope>mfrom</scope>
+        <result>pass</result>
+      </spf>
+    </auth_results>
+  </record>
+</feedback>


### PR DESCRIPTION
```
testAggregateSamples (__main__.Test)
Test sample aggregate/rua DMARC reports ... ERROR
testBase64Decoding (__main__.Test)
Test base64 decoding ... ok
testEmptySample (__main__.Test)
Test empty/unparasable report ... ok
testForensicSamples (__main__.Test)
Test sample forensic/ruf/failure DMARC reports ... ok
testPSLDownload (__main__.Test) ... ok
======================================================================
Testing samples/aggregate/Report domain- borschow.com Submitter- google.com Report-ID- [9](https://github.com/yktakaha4/parsedmarc/actions/runs/7691856259/job/20957819252?pr=1#step:8:10)49348866075514174.eml: Passed!
Testing samples/aggregate/example.net!example.com!1529366400!1529452799.xml: Passed!
Testing samples/aggregate/addisonfoods.com!example.com!1536[10](https://github.com/yktakaha4/parsedmarc/actions/runs/7691856259/job/20957819252?pr=1#step:8:11)5600!1536191999.xml: Passed!
Testing samples/aggregate/estadocuenta1.infonacot.gob.mx!example.com!1536853302!1536939702!2940.xml.zip: Passed!
Testing samples/aggregate/twilight.eml: Passed!
Testing samples/aggregate/invalid_xml.xml: Passed!
Testing samples/aggregate/ikea.com!example.de!1538690400!1538776800.xml: Passed!
Testing samples/aggregate/veeam.com!example.com!1530[13](https://github.com/yktakaha4/parsedmarc/actions/runs/7691856259/job/20957819252?pr=1#step:8:14)3200!1530219600.xml: Passed!
Testing samples/aggregate/fastmail.com!example.com!1516060800!1516[14](https://github.com/yktakaha4/parsedmarc/actions/runs/7691856259/job/20957819252?pr=1#step:8:15)7199!102675056.xml.gz: Passed!
Testing samples/aggregate/usssa.com!example.com![15](https://github.com/yktakaha4/parsedmarc/actions/runs/7691856259/job/20957819252?pr=1#step:8:16)38784000!1538870399.xml: Passed!
Testing samples/aggregate/!example.com!1538204542!1538463818.xml: Passed!
Testing samples/aggregate/empty_reason.xml: 
ERROR: testAggregateSamples (__main__.Test)
Test sample aggregate/rua DMARC reports
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests.py", line 39, in testAggregateSamples
    parsedmarc.parsed_aggregate_reports_to_csv(parsed_report)
  File "/home/runner/work/parsedmarc/parsedmarc/parsedmarc/__init__.py", line 583, in parsed_aggregate_reports_to_csv
    rows = parsed_aggregate_reports_to_csv_rows(reports)
  File "/home/runner/work/parsedmarc/parsedmarc/parsedmarc/__init__.py", line 5[17](https://github.com/yktakaha4/parsedmarc/actions/runs/7691856259/job/20957819252?pr=1#step:8:18), in parsed_aggregate_reports_to_csv_rows
    row["policy_override_reasons"] = ",".join(
TypeError: sequence item 0: expected str instance, NoneType found
----------------------------------------------------------------------
Ran 5 tests in 5.[35](https://github.com/yktakaha4/parsedmarc/actions/runs/7691856259/job/20957819252?pr=1#step:8:36)3s
FAILED (errors=1)
```